### PR TITLE
ci: Replace git token in push tag workflow with app token

### DIFF
--- a/.github/workflows/push-tag.yaml
+++ b/.github/workflows/push-tag.yaml
@@ -15,8 +15,16 @@ jobs:
     if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'releases/')
     runs-on: ubuntu-latest
     steps:
+      - name: Generate App Token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_ID_BLENDFACTORY_TAG_PUSHER }}
+          private-key: ${{ secrets.PRIVATE_KEY_BLENDFACTORY_TAG_PUSHER }}
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
       - name: Extract Version
         id: extract-version
         run: .github/scripts/extract-version.sh


### PR DESCRIPTION
Closes #32 