### PR TITLE
ci: update actions to fixed versions in Dart project setup

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -4,13 +4,17 @@ description: "Set up a Dart project"
 runs:
   using: "composite"
   steps:
+    # https://github.com/blendfactory/dvm-config-action
     - name: Extract Dart Version
-      uses: blendfactory/dvm-config-action@v1
+      uses: blendfactory/dvm-config-action@6acb8c906e9a5a3633e57243e65f8a693bf11b79 # v1.0.0
       id: dvm-config-action
+
+    # https://github.com/dart-lang/setup-dart
     - name: Set up Dart
-      uses: dart-lang/setup-dart@v1
+      uses: dart-lang/setup-dart@fedb1266e91cf51be2fdb382869461a434b920a3 # v1.6.2
       with:
         sdk: ${{ steps.dvm-config-action.outputs.dart-sdk-version }}
+
     - name: Get dependencies
       run: dart pub get
       shell: bash


### PR DESCRIPTION
- Specify fixed versions for `dvm-config-action` and `setup-dart` actions to ensure consistent behavior
  - Use `dvm-config-action@6acb8c906e9a5a3633e57243e65f8a693bf11b79` (v1.0.0) for extracting Dart version
  - Set `dart-lang/setup-dart@fedb1266e91cf51be2fdb382869461a434b920a3` (v1.6.2) for setting up Dart
- Add comments with URLs to reference the sources of the GitHub Actions used
- Include a step for fetching dependencies with `dart pub get`