### PR TITLE
feat: Add `--latest` option flag to `dvm releases`

### DIFF
--- a/lib/src/app/command_services/releases_command_services.dart
+++ b/lib/src/app/command_services/releases_command_services.dart
@@ -36,9 +36,15 @@ final class ReleasesCommandService {
 
   Future<ExitStatus> call({
     required SdkChannel channel,
+    required bool isLatest,
   }) async {
     try {
       final versions = await _sdkService.getSdks(channel: channel);
+      if (isLatest) {
+        final latestVersion = versions.last;
+        _consoleService.info(latestVersion.toString());
+        return ExitStatus.success;
+      }
       for (final version in versions) {
         _consoleService.info(version.toString());
       }

--- a/lib/src/app/commands/releases_command.dart
+++ b/lib/src/app/commands/releases_command.dart
@@ -42,6 +42,9 @@ final class ReleasesCommand extends AppCommand {
     final releasesCommandService =
         appContainer.read(releasesCommandServiceProvider);
 
-    return releasesCommandService.call(channel: sdkChannel);
+    return releasesCommandService.call(
+      channel: sdkChannel,
+      isLatest: isLatest,
+    );
   }
 }

--- a/lib/src/app/commands/releases_command.dart
+++ b/lib/src/app/commands/releases_command.dart
@@ -5,6 +5,7 @@ import 'package:dvmx/src/app/models/exit_status.dart';
 import 'package:dvmx/src/features/sdk/models/sdk_channel.dart';
 
 const _channelKey = 'channel';
+const _latestKey = 'latest';
 
 final class ReleasesCommand extends AppCommand {
   ReleasesCommand() {
@@ -14,6 +15,12 @@ final class ReleasesCommand extends AppCommand {
       abbr: 'c',
       allowed: SdkChannel.values.map((c) => c.name),
       defaultsTo: SdkChannel.stable.name,
+    );
+    argParser.addFlag(
+      _latestKey,
+      abbr: 'l',
+      help: 'Show only the latest release',
+      negatable: false,
     );
   }
 
@@ -30,6 +37,7 @@ final class ReleasesCommand extends AppCommand {
   Future<ExitStatus> run() async {
     final channel = argResults[_channelKey] as String;
     final sdkChannel = SdkChannel.values.byName(channel);
+    final isLatest = argResults.wasParsed(_latestKey);
 
     final releasesCommandService =
         appContainer.read(releasesCommandServiceProvider);

--- a/lib/src/app/commands/releases_command.dart
+++ b/lib/src/app/commands/releases_command.dart
@@ -4,10 +4,12 @@ import 'package:dvmx/src/app/command_services/releases_command_services.dart';
 import 'package:dvmx/src/app/models/exit_status.dart';
 import 'package:dvmx/src/features/sdk/models/sdk_channel.dart';
 
+const _channelKey = 'channel';
+
 final class ReleasesCommand extends AppCommand {
   ReleasesCommand() {
     argParser.addOption(
-      'channel',
+      _channelKey,
       help: 'Filter by channel name',
       abbr: 'c',
       allowed: SdkChannel.values.map((c) => c.name),
@@ -26,7 +28,7 @@ final class ReleasesCommand extends AppCommand {
 
   @override
   Future<ExitStatus> run() async {
-    final channel = argResults['channel'] as String;
+    final channel = argResults[_channelKey] as String;
     final sdkChannel = SdkChannel.values.byName(channel);
 
     final releasesCommandService =


### PR DESCRIPTION
Closes #11 

This commit enhances the `ReleasesCommandService` by adding support for filtering to show only the latest SDK release. It introduces a new parameter `isLatest` to the service call method, which, when set to `true`, results in the service outputting only the most recent release information. This functionality is integrated with the `ReleasesCommand` to provide users with an option to view just the latest release details, improving the command's utility for users interested in the most current release without the need to sift through all available versions.