### PR TITLE
feat: support `latest` option in SDK install

### DIFF
--- a/lib/src/app/command_services/install_command_service.dart
+++ b/lib/src/app/command_services/install_command_service.dart
@@ -2,6 +2,7 @@ import 'package:dvmx/src/app/models/exit_status.dart';
 import 'package:dvmx/src/app/servicies/abi_service.dart';
 import 'package:dvmx/src/app/servicies/console_service.dart';
 import 'package:dvmx/src/features/project_config/services/project_config_service.dart';
+import 'package:dvmx/src/features/sdk/models/sdk_channel.dart';
 import 'package:dvmx/src/features/sdk/models/sdk_version.dart';
 import 'package:dvmx/src/features/sdk/services/sdk_service.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -49,8 +50,23 @@ final class InstallCommandService {
 
   Future<ExitStatus> call({
     required SdkVersion? version,
+    required LatestOptions latestOptions,
     required ThrowUsageException throwUsageException,
   }) async {
+    if (latestOptions.isLatest) {
+      final version = await _sdkService.getLatestSdk(
+        channel: latestOptions.channel,
+      );
+      return call(
+        version: version,
+        latestOptions: (
+          isLatest: false,
+          channel: latestOptions.channel,
+        ),
+        throwUsageException: throwUsageException,
+      );
+    }
+
     final SdkVersion sdkVersion;
     if (version == null) {
       final projectSdkVersion = _projectConfigService.findProjectSdkVersion();
@@ -89,5 +105,10 @@ final class InstallCommandService {
     return ExitStatus.success;
   }
 }
+
+typedef LatestOptions = ({
+  bool isLatest,
+  SdkChannel channel,
+});
 
 typedef ThrowUsageException = Never Function(String message);

--- a/lib/src/app/command_services/releases_command_services.dart
+++ b/lib/src/app/command_services/releases_command_services.dart
@@ -39,12 +39,13 @@ final class ReleasesCommandService {
     required bool isLatest,
   }) async {
     try {
-      final versions = await _sdkService.getSdks(channel: channel);
       if (isLatest) {
-        final latestVersion = versions.last;
-        _consoleService.info(latestVersion.toString());
+        final version = await _sdkService.getLatestSdk(channel: channel);
+        _consoleService.info(version.toString());
         return ExitStatus.success;
       }
+
+      final versions = await _sdkService.getSdks(channel: channel);
       for (final version in versions) {
         _consoleService.info(version.toString());
       }

--- a/lib/src/app/commands/dart_command.dart
+++ b/lib/src/app/commands/dart_command.dart
@@ -14,7 +14,7 @@ final class DartCommand extends AppCommand {
   final description = 'Proxy a dart command.';
 
   @override
-  String get invocation => 'dvm dart <args>';
+  String get invocation => 'dvm dart <args>.';
 
   @override
   List<String> get aliases => ['d'];

--- a/lib/src/app/commands/install_command.dart
+++ b/lib/src/app/commands/install_command.dart
@@ -62,6 +62,10 @@ final class InstallCommand extends AppCommand {
 
     return installCommandService.call(
       version: sdkVersion,
+      latestOptions: (
+        isLatest: isLatest,
+        channel: sdkChannel,
+      ),
       throwUsageException: usageException,
     );
   }

--- a/lib/src/app/commands/install_command.dart
+++ b/lib/src/app/commands/install_command.dart
@@ -2,10 +2,29 @@ import 'package:dvmx/dvmx.dart';
 import 'package:dvmx/src/app/app_commnad.dart';
 import 'package:dvmx/src/app/app_container.dart';
 import 'package:dvmx/src/app/command_services/install_command_service.dart';
+import 'package:dvmx/src/features/sdk/models/sdk_channel.dart';
 import 'package:dvmx/src/features/sdk/models/sdk_version.dart';
 
+const _latestKey = 'latest';
+const _channelKey = 'channel';
+
 final class InstallCommand extends AppCommand {
-  InstallCommand();
+  InstallCommand() {
+    argParser.addFlag(
+      _latestKey,
+      abbr: 'l',
+      help: 'Install the latest release',
+      negatable: false,
+    );
+    argParser.addOption(
+      _channelKey,
+      help:
+          '''Used only if the `latest` option is specified. Specifies from which channel the latest release is installed.''',
+      abbr: 'c',
+      allowed: SdkChannel.values.map((c) => c.name),
+      defaultsTo: SdkChannel.stable.name,
+    );
+  }
 
   @override
   final name = 'install';
@@ -33,6 +52,10 @@ final class InstallCommand extends AppCommand {
         usageException(e.message);
       }
     }
+
+    final channel = argResults[_channelKey] as String;
+    final sdkChannel = SdkChannel.values.byName(channel);
+    final isLatest = argResults.wasParsed(_latestKey);
 
     final installCommandService =
         appContainer.read(installCommandServiceProvider);

--- a/lib/src/app/commands/install_command.dart
+++ b/lib/src/app/commands/install_command.dart
@@ -19,9 +19,9 @@ final class InstallCommand extends AppCommand {
     );
     argParser.addOption(
       _channelKey,
+      abbr: 'c',
       help:
           '''Used only if the `latest` option is specified. Specifies from which channel the latest release is installed.''',
-      abbr: 'c',
       allowed: SdkChannel.values.map((c) => c.name),
       defaultsTo: SdkChannel.stable.name,
     );

--- a/lib/src/app/commands/install_command.dart
+++ b/lib/src/app/commands/install_command.dart
@@ -13,7 +13,8 @@ final class InstallCommand extends AppCommand {
     argParser.addFlag(
       _latestKey,
       abbr: 'l',
-      help: 'Install the latest release',
+      help:
+          '''Install the latest release. This option takes precedence even if a version is specified.''',
       negatable: false,
     );
     argParser.addOption(

--- a/lib/src/app/commands/list_command.dart
+++ b/lib/src/app/commands/list_command.dart
@@ -8,8 +8,8 @@ final class ListCommand extends AppCommand {
   ListCommand() {
     argParser.addOption(
       'channel',
-      help: 'Filter by channel name',
       abbr: 'c',
+      help: 'Filter by channel name',
       allowed: SdkChannel.values.map((c) => c.name),
     );
   }

--- a/lib/src/app/commands/list_command.dart
+++ b/lib/src/app/commands/list_command.dart
@@ -9,7 +9,7 @@ final class ListCommand extends AppCommand {
     argParser.addOption(
       'channel',
       abbr: 'c',
-      help: 'Filter by channel name',
+      help: 'Filter by channel name.',
       allowed: SdkChannel.values.map((c) => c.name),
     );
   }

--- a/lib/src/app/commands/releases_command.dart
+++ b/lib/src/app/commands/releases_command.dart
@@ -12,14 +12,14 @@ final class ReleasesCommand extends AppCommand {
     argParser.addOption(
       _channelKey,
       abbr: 'c',
-      help: 'Filter by channel name',
+      help: 'Filter by channel name.',
       allowed: SdkChannel.values.map((c) => c.name),
       defaultsTo: SdkChannel.stable.name,
     );
     argParser.addFlag(
       _latestKey,
       abbr: 'l',
-      help: 'Show only the latest release',
+      help: 'Show only the latest release.',
       negatable: false,
     );
   }

--- a/lib/src/app/commands/releases_command.dart
+++ b/lib/src/app/commands/releases_command.dart
@@ -11,8 +11,8 @@ final class ReleasesCommand extends AppCommand {
   ReleasesCommand() {
     argParser.addOption(
       _channelKey,
-      help: 'Filter by channel name',
       abbr: 'c',
+      help: 'Filter by channel name',
       allowed: SdkChannel.values.map((c) => c.name),
       defaultsTo: SdkChannel.stable.name,
     );

--- a/lib/src/app/commands/uninstall_command.dart
+++ b/lib/src/app/commands/uninstall_command.dart
@@ -11,7 +11,7 @@ final class UninstallCommand extends AppCommand {
     argParser.addFlag(
       _allFlagKey,
       abbr: 'a',
-      help: 'Uninstall all Dart SDKs',
+      help: 'Uninstall all Dart SDKs.',
       negatable: false,
     );
   }

--- a/lib/src/features/sdk/services/sdk_service.dart
+++ b/lib/src/features/sdk/services/sdk_service.dart
@@ -112,6 +112,16 @@ final class SdkService {
     return versions;
   }
 
+  Future<SdkVersion> getLatestSdk({
+    required SdkChannel channel,
+  }) async {
+    final versions = await getSdks(channel: channel);
+    if (versions.isEmpty) {
+      throw Exception('Could not find Dart SDK');
+    }
+    return versions.last;
+  }
+
   Future<List<SdkVersion>> getInstalledSdks({
     required SdkChannel? channel,
   }) async {


### PR DESCRIPTION
Closes #17

This commit introduces functionality to handle the `latest` option when installing SDK versions. A new `LatestOptions` type and an `sdkChannel` parameter have been added to support this feature, allowing the installation of the latest SDK version from a specified channel. This update enhances the `InstallCommandService` and `InstallCommand` classes to accommodate the latest SDK installation process, improving the tool's flexibility and user experience in managing SDK versions.